### PR TITLE
chore: remove surge.sh support

### DIFF
--- a/dr-surge.js
+++ b/dr-surge.js
@@ -1,7 +1,0 @@
-const fs = require('fs');
-const path = require('path');
-const indexPath = path.resolve(__dirname, 'dist/index.html');
-const targetFilePath = path.resolve(__dirname, 'dist/200.html');
-// ensure we have bookmarkable url's when publishing to surge
-// https://surge.sh/help/adding-a-200-page-for-client-side-routing
-fs.createReadStream(indexPath).pipe(fs.createWriteStream(targetFilePath));

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,11 @@
         "@patternfly/react-icons": "5.1.2",
         "@patternfly/react-styles": "5.1.2",
         "@storybook/builder-webpack5": "7.6.8",
-        "papaparse": "5.4.1",
         "react": "18",
-        "react-dom": "18",
-        "sirv-cli": "2.0.2"
+        "react-dom": "18"
       },
       "devDependencies": {
-        "@patternfly/react-charts": "^7.1.2",
+        "@patternfly/react-charts": "7.1.2",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "2.0.3",
         "@storybook/addon-actions": "7.6.8",
         "@storybook/addon-info": "5.3.21",
@@ -38,7 +36,7 @@
         "copy-webpack-plugin": "12.0.1",
         "css-loader": "6.9.0",
         "css-minimizer-webpack-plugin": "5.0.1",
-        "csv-loader": "^3.0.5",
+        "csv-loader": "3.0.5",
         "dotenv-webpack": "8.0.1",
         "eslint": "8.56.0",
         "eslint-plugin-react": "7.33.2",
@@ -48,6 +46,7 @@
         "jest": "29.7.0",
         "jest-environment-jsdom": "29.7.0",
         "mini-css-extract-plugin": "2.7.7",
+        "papaparse": "5.4.1",
         "postcss": "8.4.33",
         "prettier": "3.2.2",
         "prop-types": "15.8.1",
@@ -57,6 +56,7 @@
         "react-router-dom": "5.3.4",
         "regenerator-runtime": "0.14.1",
         "rimraf": "5.0.5",
+        "sirv-cli": "2.0.2",
         "style-loader": "3.3.4",
         "svg-url-loader": "8.0.0",
         "terser-webpack-plugin": "5.3.10",
@@ -2574,7 +2574,8 @@
     "node_modules/@polka/url": {
       "version": "1.0.0-next.24",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz",
-      "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ=="
+      "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==",
+      "dev": true
     },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
@@ -8259,6 +8260,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/console-clear/-/console-clear-1.1.1.tgz",
       "integrity": "sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11966,6 +11968,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
       "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -16140,6 +16143,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/local-access/-/local-access-1.1.0.tgz",
       "integrity": "sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -16789,6 +16793,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -16797,6 +16802,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
       "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -17523,7 +17529,8 @@
     "node_modules/papaparse": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
-      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+      "dev": true
     },
     "node_modules/parallel-transform": {
       "version": "1.2.0",
@@ -20317,6 +20324,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
       "dependencies": {
         "mri": "^1.1.0"
       },
@@ -20492,6 +20500,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/semiver/-/semiver-1.1.0.tgz",
       "integrity": "sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -20855,6 +20864,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
       "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
       "dependencies": {
         "@polka/url": "^1.0.0-next.24",
         "mrmime": "^2.0.0",
@@ -20868,6 +20878,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/sirv-cli/-/sirv-cli-2.0.2.tgz",
       "integrity": "sha512-OtSJDwxsF1NWHc7ps3Sa0s+dPtP15iQNJzfKVz+MxkEo3z72mCD+yu30ct79rPr0CaV1HXSOBp+MIY5uIhHZ1A==",
+      "dev": true,
       "dependencies": {
         "console-clear": "^1.1.0",
         "get-port": "^3.2.0",
@@ -20889,6 +20900,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -22144,6 +22156,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/tinydate/-/tinydate-1.3.0.tgz",
       "integrity": "sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -22257,6 +22270,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
       "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "private": true,
   "scripts": {
     "prebuild": "npm run type-check && npm run clean",
-    "dr:surge": "node dr-surge.js",
-    "build": "webpack --config webpack.prod.js && npm run dr:surge",
+    "build": "webpack --config webpack.prod.js",
     "start": "sirv dist --cors --single --host --port 8080",
     "start:dev": "webpack serve --color --progress --config webpack.dev.js",
     "test": "jest",
@@ -56,6 +55,7 @@
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "mini-css-extract-plugin": "2.7.7",
+    "papaparse": "5.4.1",
     "postcss": "8.4.33",
     "prettier": "3.2.2",
     "prop-types": "15.8.1",
@@ -65,6 +65,7 @@
     "react-router-dom": "5.3.4",
     "regenerator-runtime": "0.14.1",
     "rimraf": "5.0.5",
+    "sirv-cli": "2.0.2",
     "style-loader": "3.3.4",
     "svg-url-loader": "8.0.0",
     "terser-webpack-plugin": "5.3.10",
@@ -85,9 +86,7 @@
     "@patternfly/react-icons": "5.1.2",
     "@patternfly/react-styles": "5.1.2",
     "@storybook/builder-webpack5": "7.6.8",
-    "papaparse": "5.4.1",
     "react": "18",
-    "react-dom": "18",
-    "sirv-cli": "2.0.2"
+    "react-dom": "18"
   }
 }


### PR DESCRIPTION
Site will be published using GitHub pages, so surge.sh support is not needed.