### PR TITLE
chore: group select dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      patternfly:
+        patterns:
+          - "@patternfly"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Group the patternfly and typescript-eslint dependencies since the patternfly dependencies update together and the typescript-eslint dependencies must be upgrades together.